### PR TITLE
Lower Ruby requirement and expand CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.4']
-        rails-version: ['7.2.0']
+        ruby-version: ['3.2', '3.3', '3.4']
+        rails-version: ['7.2.0', '8.1']
     
     steps:
       - name: Check out code

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ A production-safe gem for comprehensive inbound HTTP request logging in Rails ap
 - **SQLite logging**: Optional separate SQLite database for local logging and testing
 - **Test utilities**: Persistent test logging with request counting and analysis tools
 
+## Requirements
+
+This gem supports Ruby 3.2 or newer and Rails 7.2 or newer. The CI matrix also
+tests against Ruby 3.3 and Rails 8.1 to ensure compatibility.
+
 ## Installation
 
 Add to your Gemfile:

--- a/inbound_http_logger.gemspec
+++ b/inbound_http_logger.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A gem for logging inbound HTTP requests with Rack middleware, controller-level filtering, and configurable security features."
   spec.homepage = "https://github.com/getupgraded/inbound_http_logger"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.4.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir.glob("{lib,test}/**/*") + %w[README.md Rakefile inbound_http_logger.gemspec]


### PR DESCRIPTION
## Summary
- relax required_ruby_version to 3.2
- document supported versions in README
- test multiple Ruby and Rails versions in GitHub Actions

## Testing
- `bundle exec rake test`
- `bundle exec rubocop --config .rubocop.yml` (fails)

------
https://chatgpt.com/codex/tasks/task_e_685a7264b7b08322a3c916643e42800f