### PR TITLE
Enhance CI matrix with more Ruby and Rails versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.4']
-        rails-version: ['7.2.0']
+        ruby-version: ['3.4', '3.3']
+        rails-version: ['7.2.0', '8.1.0']
     
     steps:
       - name: Check out code


### PR DESCRIPTION
## Summary
- include Ruby 3.3 and Rails 8.1.0 in the GitHub Actions test matrix

## Testing
- `bundle exec rake test`
- `bundle exec rubocop --config .rubocop.yml` *(fails: many offenses)*

------
https://chatgpt.com/codex/tasks/task_e_685a7224a7748322945d09b9d70a6155