### PR TITLE
Add migration generator test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,7 @@ GEM
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
+    pg (1.5.9)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -297,6 +298,7 @@ DEPENDENCIES
   irb
   minitest (~> 5.0)
   mocha (~> 2.0)
+  pg (>= 1.5)
   rails (>= 7.2.0)
   rake (~> 13.0)
   rubocop (~> 1.75)

--- a/inbound_http_logger.gemspec
+++ b/inbound_http_logger.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rake", "~> 0.7"
   spec.add_development_dependency "rubocop-thread_safety", "~> 0.7"
   spec.add_development_dependency "sqlite3", ">= 2.1"
+  spec.add_development_dependency "pg", ">= 1.5"
   spec.add_development_dependency 'webmock', '~> 3.0'
 
   # For more information and examples about making a new gem, check out our

--- a/test/generators/test_migration_generator.rb
+++ b/test/generators/test_migration_generator.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "minitest/spec"
+require "active_record"
+require "rails/generators"
+require "rails/generators/active_record"
+require "inbound_http_logger/generators/migration_generator"
+require "tmpdir"
+require "fileutils"
+
+describe InboundHttpLogger::Generators::MigrationGenerator do
+  before do
+    @tmp = Dir.mktmpdir
+    FileUtils.mkdir_p(File.join(@tmp, "db/migrate"))
+    InboundHttpLogger::Generators::MigrationGenerator.start([], destination_root: @tmp)
+    @migration_path = Dir.glob(File.join(@tmp, "db/migrate/*.rb")).first
+    load @migration_path
+    ActiveRecord::Migration.verbose = false
+  end
+
+  after do
+    FileUtils.remove_entry(@tmp)
+    Object.send(:remove_const, :CreateInboundRequestLogs) if defined?(CreateInboundRequestLogs)
+  end
+
+  def run_migration(config)
+    ActiveRecord::Base.establish_connection(config)
+    migration = CreateInboundRequestLogs.new
+    migration.migrate(:up)
+
+    connection = ActiveRecord::Base.connection
+    assert connection.table_exists?(:inbound_request_logs)
+
+    json_column = connection.columns(:inbound_request_logs).find { |c| c.name == "request_headers" }
+    if connection.adapter_name == "PostgreSQL"
+      _(json_column.sql_type).must_equal "jsonb"
+    else
+      _(json_column.sql_type).must_equal "json"
+    end
+
+    index_names = connection.indexes(:inbound_request_logs).map(&:name)
+    _(index_names).must_include "index_inbound_request_logs_on_failed_requests"
+    if connection.adapter_name == "PostgreSQL"
+      _(index_names).must_include "index_inbound_request_logs_on_response_body_gin"
+    end
+
+    migration.migrate(:down)
+    refute connection.table_exists?(:inbound_request_logs)
+  end
+
+  it "generates a migration that runs on SQLite" do
+    run_migration(adapter: "sqlite3", database: ":memory:")
+  end
+
+  it "generates a migration that runs on PostgreSQL" do
+    run_migration(adapter: "postgresql", database: "inbound_test", username: "postgres", password: "postgres", host: "localhost")
+  end
+end


### PR DESCRIPTION
## Summary
- add pg as development dependency for PostgreSQL tests
- test the migration generator with SQLite and PostgreSQL

## Testing
- `bundle exec rake test TEST=test/generators/test_migration_generator.rb`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_685a719ae1b48322b76840add334db37